### PR TITLE
Remove incorrect return statement in run_env.py

### DIFF
--- a/experiments/run_env.py
+++ b/experiments/run_env.py
@@ -168,7 +168,6 @@ def main(args):
             print(
                 f"joint[{i}]: \t delta: {delta:4.3f} , leader: \t{joint:4.3f} , follower: \t{current_j:4.3f}"
             )
-        return
 
     print(f"Start pos: {len(start_pos)}", f"Joints: {len(joints)}")
     assert len(start_pos) == len(


### PR DESCRIPTION
Fixes an issue where run_env will exit early.