### PR TITLE
add: import DynamixelDriver in driver.py

### DIFF
--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/driver.py
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/driver.py
@@ -1,0 +1,1 @@
+from gello.dynamixel.driver import DynamixelDriver


### PR DESCRIPTION
When installing and building the ros2 stuff, launching the franka_gello_state_publisher errors because it cannot import dynamixel from the driver.py file, just fixed this by adding in the correct import statement 