### PR TITLE
fix: update frankaemika github links to frankarobotics

### DIFF
--- a/ros2/.devcontainer/Dockerfile
+++ b/ros2/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
 # Install libfranka
 ARG LIBFRANKA_VERSION=0.15.0
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
-  git clone --recursive https://github.com/frankaemika/libfranka --branch ${LIBFRANKA_VERSION} \
+  git clone --recursive https://github.com/frankarobotics/libfranka --branch ${LIBFRANKA_VERSION} \
   && cd libfranka \
   && mkdir build \
   && cd build \
@@ -34,8 +34,8 @@ ARG FRANKA_ROS2_VERSION=v1.0.0
 ARG FRANKA_DESCRIPTION_VERSION=0.4.0
 RUN /bin/bash -c 'source /opt/ros/humble/setup.bash && \
   mkdir -p /tmp/franka_ros2 && cd /tmp/franka_ros2 && \
-  git clone --recursive https://github.com/frankaemika/franka_ros2.git --branch ${FRANKA_ROS2_VERSION} && \
-  git clone --recursive https://github.com/frankaemika/franka_description.git --branch ${FRANKA_DESCRIPTION_VERSION} && \
+  git clone --recursive https://github.com/frankarobotics/franka_ros2.git --branch ${FRANKA_ROS2_VERSION} && \
+  git clone --recursive https://github.com/frankarobotics/franka_description.git --branch ${FRANKA_DESCRIPTION_VERSION} && \
   apt-get update && \
   rosdep update && \
   rosdep install --from-paths . --ignore-src -r -y && \

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -50,7 +50,7 @@ If you choose not to use the Dev-Container, please refer to the [Local Setup](#l
 - **ROS 2 Humble Desktop** must be installed.  
   See the [official installation guide](https://docs.ros.org/en/humble/Installation.html) for instructions.
 - **libfranka** and **franka_ros2** must be installed.  
-  Refer to the [Franka Robotics documentation](https://frankaemika.github.io/docs/index.html) for installation steps and compatibility information.
+  Refer to the [Franka Robotics documentation](https://frankarobotics.github.io/docs/index.html) for installation steps and compatibility information.
 - **ros2_robotiq_gripper** (if required) must be installed.  
   See the [ros2_robotiq_gripper GitHub repository](https://github.com/PickNikRobotics/ros2_robotiq_gripper) for installation and usage instructions.
 
@@ -168,7 +168,7 @@ The open com port could not be opened. Possible reasons are:
   
 ### libfranka: Incompatible library version (server version: X, library version: Y).
 
-The libfranka version and robot system version are not compatible. More information can be found [here](https://frankaemika.github.io/docs/compatibility.html).
+The libfranka version and robot system version are not compatible. More information can be found [here](https://frankarobotics.github.io/docs/compatibility.html).
 Fix this by correcting the `LIBFRANKA_VERSION=0.15.0` in the [Dockerfile](./.devcontainer/Dockerfile) and update the `FRANKA_ROS2_VERSION` and `FRANKA_DESCRIPTION_VERSION` accordingly.
 
 


### PR DESCRIPTION
### Summary

The original GitHub repository for **Franka Emika** is no longer available. It has been moved to **Franka Robotics**'s new GitHub organization. This PR updates all references from the old `frankaemika` GitHub URLs to the new `frankarobotics` URLs to ensure continued compatibility and correctness.

### Changes Made
- Replaced all links and references to `github.com/frankaemika` with `github.com/frankarobotics`.
- Verified affected files for correctness.