### PR TITLE
fix: ros2 devcontainer build failure

### DIFF
--- a/ros2/.devcontainer/Dockerfile
+++ b/ros2/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install libfranka
-ARG LIBFRANKA_VERSION=0.15.0
+ARG LIBFRANKA_VERSION=0.17.0
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
   git clone --recursive https://github.com/frankarobotics/libfranka --branch ${LIBFRANKA_VERSION} \
   && cd libfranka \
@@ -30,8 +30,8 @@ RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
   && cd ../../ && rm -r libfranka"
 
 # Install franka_ros2
-ARG FRANKA_ROS2_VERSION=v2.0.1
-ARG FRANKA_DESCRIPTION_VERSION=1.0.0
+ARG FRANKA_ROS2_VERSION=v2.0.4
+ARG FRANKA_DESCRIPTION_VERSION=1.0.2
 RUN /bin/bash -c 'source /opt/ros/humble/setup.bash && \
   mkdir -p /tmp/franka_ros2 && cd /tmp/franka_ros2 && \
   git clone --recursive https://github.com/frankarobotics/franka_ros2.git --branch ${FRANKA_ROS2_VERSION} && \


### PR DESCRIPTION
### Description
This PR fixes the ROS 2 dev container build failure by updating Franka-related dependencies to their latest compatible versions.

### Changes
- **Updated dependencies:**
  - `LIBFRANKA_VERSION`: `0.15.0` → `0.17.0`  
  - `FRANKA_ROS2_VERSION`: `v2.0.1` → `v2.0.4`  
  - `FRANKA_DESCRIPTION_VERSION`: `1.0.0` → `1.0.2`

These updates resolve build errors encountered during the dev container setup.
