### PR TITLE
Update to pyspacemouse 2.1.0

### DIFF
--- a/gello/agents/spacemouse_agent.py
+++ b/gello/agents/spacemouse_agent.py
@@ -74,9 +74,10 @@ class SpacemouseAgent(Agent):
         import pyspacemouse
 
         if self._device_path is None:
-            mouse = pyspacemouse.open()
+            mouse = pyspacemouse.open(axis_convention=pyspacemouse.AxisConvention.HID_Z_UP)
         else:
-            mouse = pyspacemouse.open(path=self._device_path)
+            mouse = pyspacemouse.open_by_path(self._device_path,
+                axis_convention=pyspacemouse.AxisConvention.HID_Z_UP)
         if mouse:
             while 1:
                 state = mouse.read()
@@ -143,21 +144,21 @@ class SpacemouseAgent(Agent):
         rot_transform_x = np.eye(4)
         rot_transform_x[:3, :3] = quaternion.as_rotation_matrix(
             quaternion.from_rotation_vector(
-                np.array([-p, 0, 0]) * self.config.angle_scale
+                np.array([r, 0, 0]) * self.config.angle_scale
             )
         )
 
         rot_transform_y = np.eye(4)
         rot_transform_y[:3, :3] = quaternion.as_rotation_matrix(
             quaternion.from_rotation_vector(
-                np.array([0, r, 0]) * self.config.angle_scale
+                np.array([0, p, 0]) * self.config.angle_scale
             )
         )
 
         rot_transform_z = np.eye(4)
         rot_transform_z[:3, :3] = quaternion.as_rotation_matrix(
             quaternion.from_rotation_vector(
-                np.array([0, 0, -y]) * self.config.angle_scale
+                np.array([0, 0, y]) * self.config.angle_scale
             )
         )
 
@@ -220,5 +221,5 @@ class SpacemouseAgent(Agent):
 if __name__ == "__main__":
     import pyspacemouse
 
-    success = pyspacemouse.open("/dev/hidraw4")
-    success = pyspacemouse.open("/dev/hidraw5")
+    success = pyspacemouse.open_by_path("/dev/hidraw4")
+    success = pyspacemouse.open_by_path("/dev/hidraw5")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ omegaconf==2.3.0
 Pillow
 pin==3.7.0
 pygame
-pyspacemouse
+pyspacemouse>=2.1.0
 PyQt6
 pyquaternion
 pyrealsense2


### PR DESCRIPTION
Since the new major version 2.0, the API for opening by path has changed.

And specifically with 2.1.0, there is we can specify the HID_Z_UP convention which should be equivalent to the previous code.

Currently, the version of pyspacemouse is unpinned, meaning that anyone who tries to set up the dev environment now and use spacemice by path will silently have problems, because the spacemouse that gets open could be the wrong spacemouse!