### PR TITLE
feat: configurable Dynamixel baudrate and publishing_rate

### DIFF
--- a/ros2/CHANGELOG.md
+++ b/ros2/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 > This changelog covers only the changes relevant to the ROS 2 implementation of GELLO.
 
+## `ros2-v2.2.0` - 2026-08-31
+ - Added a configurable `baudrate` parameter for the Dynamixel chain in the publisher's config files
+   (`57600` factory, `115200` or `1000000`), replacing the previously hard-coded `57600`.
+ - Added a configurable `publishing_rate` parameter in the publisher's config files, replacing the
+   previously hard-coded 25 Hz. The node warns when the requested rate exceeds the unique-sample
+   ceiling of the configured baud rate, but still starts.
+ - **Behavioral**: On startup, the publisher scans the known baud rates until all expected motor IDs
+   answer. If the live chain baud rate differs from the configured `baudrate`, the motors' EEPROM
+   `baud_rate` is written and the chain is reopened at the configured rate. Mixed-baud chains abort
+   without writing.
+ - Both new parameters are optional and default to the previous values (`57600` and 25 Hz), so
+   existing config files continue to work unchanged.
+ - Added a `--baudrate` argument to the `get_offsets.py` script (defaults to `57600`, no scanning).
+ - Fixed the Dynamixel driver leaving the serial port open when initialization failed.
+ - Documented the baud rate / publish rate pairings and the `latency_timer=1` requirement in the README.
+
 ## `ros2-v2.1.0` - 2026-04-08
  - Updated the Dockerfile and Docker Compose files to support Cyclone DDS as the ROS 2 RMW.
  - **Behavioral**: Cyclone DDS is now the default RMW in the devcontainer.

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -141,6 +141,8 @@ Use the `get_offsets.py` script in `/ros2/src/franka_gello_state_publisher/scrip
       ```
 
 Use the output of the `get_offsets.py` script to update the values in your GELLO configuration file located in `/workspace/ros2/src/franka_gello_state_publisher/config/`.
+
+If the Dynamixel chain was provisioned to 115200 (or 1 Mbps), pass `--baudrate 115200` (or `1000000`). The script default is 57600 and does not scan.
       
 Rebuild the project to ensure the updated configuration is applied:
 
@@ -167,7 +169,21 @@ The `config_file` argument is **optional**. If not provided, it defaults to `exa
 - `joint_signs`: as used for calibration
 - `gripper`: true if Gello gripper state shall be used
 - `assembly_offsets` and `gripper_range_rad`: as determined with calibration routine
+- `baudrate`: XL330 serial baud (`57600` factory, `115200`, or `1000000`). Omitted keys default to `57600`. EEPROM is written only if the live chain baud differs from this value.
+- `publishing_rate`: ROS joint-state timer in Hz (any integer ≥ 1). Recommended values in the table below. Omitted keys default to `25`.
 - Dynamixel control parameters: `dynamixel_...` (see below)
+
+**Baud rate and publish rate:**
+
+The publisher scans `(desired, 115200, 57600, 1000000)` until every expected ID answers `model_number`. If live baud differs from YAML `baudrate`, it SyncWrites EEPROM `baud_rate` and reopens at the desired rate. Mixed-baud chains abort with no write. Package YAML stays factory `57600` / `25` so stock GELLOs are unchanged.
+
+| `baudrate` | Unique-Hz ceiling | Warn threshold | Recommended `publishing_rate` |
+|---|---|---|---|
+| `57600` | ~25 | 25 | **25** (factory; no EEPROM write) |
+| `115200` | ~55 | 50 | **30** or **50** |
+| `1000000` | ~135 | 100 | **100** |
+
+The table is recommended, not an enum. `publishing_rate` may be any integer ≥ 1 (e.g. `115200` → `40`). Above the warn thresholds (25 / 50 / 100) the node still starts and republishes the last sample due to the baudrate speed ceiling. `latency_timer=1` is recommended for 50 Hz at 115200 and 100 Hz at 1 Mbps (Linux FTDI default is 16 ms). See [Troubleshooting](#the-movement-of-the-follower-robot-is-slightly-jerky).
 
 **Virtual Springs and Dampers:**<a name="virtual-springs-dampers"></a>
 
@@ -302,7 +318,7 @@ Fix this by correcting the `LIBFRANKA_VERSION=0.15.0` in the [Dockerfile](./.dev
 
 ### The movement of the follower robot is slightly jerky
 
-If the movements of the follower robot do not feel smooth or you experience frequent force threshold errors, this may be related to high USB latency on your machine. To fix this, try the following (non-permanent) fix **on your host PC**:
+If the movements of the follower robot do not feel smooth or you experience frequent force threshold errors, this may be related to high USB latency on your machine. `latency_timer=1` is required for unique ~50 Hz at 115200 baud (and 100 Hz at 1 Mbps). To fix this, try the following (non-permanent) fix **on your host PC**:
 
 1. Check which `ttyUSBx`/`ttyACMx` is mapped to your U2D2 or OpenRB-150 device: `ls -la /dev/serial/by-id/`
 2. Reduce the USB latency from the default 16ms to 1ms: `echo 1 | sudo tee /sys/bus/usb-serial/devices/ttyUSB0/latency_timer` (replace `ttyUSB0` with your actual device)

--- a/ros2/src/franka_gello_state_publisher/config/example_duo.yaml
+++ b/ros2/src/franka_gello_state_publisher/config/example_duo.yaml
@@ -1,5 +1,12 @@
 # This is an example config file for two 7-DoF GELLO arms teleoperating two Franka FR3 robots.
 # Check the README to learn how to adapt it to your setup.
+#
+# baudrate = Dynamixel bus speed. publishing_rate = ROS timer (any Hz ≥ 1).
+# Defaults: 57600 / 25 (factory; no EEPROM write).
+# Unique-sample ceiling: ~25 Hz @ 57600 | ~55 @ 115200 | ~135 @ 1000000.
+# Recommended timer: 25 Hz @ 57600 | 30 or 50 Hz @ 115200 | 100 Hz @ 1000000.
+# Above the warn thresholds (25 / 50 / 100) the node still starts and republishes
+# the last sample due to the baudrate speed ceiling.
 
 LEFT:
   namespace: "left"
@@ -9,6 +16,8 @@ LEFT:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's
@@ -28,6 +37,8 @@ RIGHT:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's

--- a/ros2/src/franka_gello_state_publisher/config/example_single.yaml
+++ b/ros2/src/franka_gello_state_publisher/config/example_single.yaml
@@ -1,5 +1,12 @@
 # This is an example config file for a 7-DoF GELLO arm teleoperating a Franka FR3 robot.
 # Check the README to learn how to adapt it to your setup.
+#
+# baudrate = Dynamixel bus speed. publishing_rate = ROS timer (any Hz ≥ 1).
+# Defaults: 57600 / 25 (factory; no EEPROM write).
+# Unique-sample ceiling: ~25 Hz @ 57600 | ~55 @ 115200 | ~135 @ 1000000.
+# Recommended timer: 25 Hz @ 57600 | 30 or 50 Hz @ 115200 | 100 Hz @ 1000000.
+# Above the warn thresholds (25 / 50 / 100) the node still starts and republishes
+# the last sample due to the baudrate speed ceiling.
 
 SINGLE:
   namespace: ""
@@ -9,6 +16,8 @@ SINGLE:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's

--- a/ros2/src/franka_gello_state_publisher/config/franka_gello_duo.yaml
+++ b/ros2/src/franka_gello_state_publisher/config/franka_gello_duo.yaml
@@ -1,5 +1,12 @@
 # This configuration works with the pre-assembled "Franka GELLO Duo" by Franka Robotics GmbH
 # See https://franka.de/documents
+#
+# baudrate = Dynamixel bus speed. publishing_rate = ROS timer (any Hz ≥ 1).
+# Defaults: 57600 / 25 (factory; no EEPROM write).
+# Unique-sample ceiling: ~25 Hz @ 57600 | ~55 @ 115200 | ~135 @ 1000000.
+# Recommended timer: 25 Hz @ 57600 | 30 or 50 Hz @ 115200 | 100 Hz @ 1000000.
+# Above the warn thresholds (25 / 50 / 100) the node still starts and republishes
+# the last sample due to the baudrate speed ceiling.
 
 LEFT:
   namespace: "left"
@@ -9,6 +16,8 @@ LEFT:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's
@@ -28,6 +37,8 @@ RIGHT:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's

--- a/ros2/src/franka_gello_state_publisher/config/franka_gello_single.yaml
+++ b/ros2/src/franka_gello_state_publisher/config/franka_gello_single.yaml
@@ -1,5 +1,12 @@
 # This configuration works with the pre-assembled "Franka GELLO" (single arm) by Franka Robotics GmbH
 # See https://franka.de/documents
+#
+# baudrate = Dynamixel bus speed. publishing_rate = ROS timer (any Hz ≥ 1).
+# Defaults: 57600 / 25 (factory; no EEPROM write).
+# Unique-sample ceiling: ~25 Hz @ 57600 | ~55 @ 115200 | ~135 @ 1000000.
+# Recommended timer: 25 Hz @ 57600 | 30 or 50 Hz @ 115200 | 100 Hz @ 1000000.
+# Above the warn thresholds (25 / 50 / 100) the node still starts and republishes
+# the last sample due to the baudrate speed ceiling.
 
 SINGLE:
   namespace: ""
@@ -9,6 +16,8 @@ SINGLE:
   gripper: true
   assembly_offsets: [0.000, 0.000, 3.142, 3.142, 3.142, 4.712, 0.000] # rad
   gripper_range_rad: [2.00, 3.22]
+  baudrate: 57600          # bus speed; unique-sample ceiling
+  publishing_rate: 25      # ROS publish Hz
   # Optional Dynamixel control parameters for all arm joints (+ gripper):
   # Warning: If using the OpenRB-150 instead of the U2D2 communication converter,
   #          do not enable torque until an external 5V power supply is connected to the board's

--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/dynamixel/README.md
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/dynamixel/README.md
@@ -57,11 +57,13 @@ try:
       port="/dev/ttyUSB0", 
       baudrate=57600, 
       motor_type="xl330"
-  )
+    )
 except ConnectionError as e:
   print(f"Error initializing DynamixelDriver: {e}")
   return
 ```
+
+Host serial baudrate is passed by the caller (ROS `baudrate` param / YAML). Factory XL330 chains use 57600. Allowed values: 57600, 115200, 1000000 (control-table register 1 / 2 / 3). The GELLO publisher scans these rates on init and may SyncWrite EEPROM `baud_rate` when YAML requests a different allowed baud.
 
 ### Fake Driver for Testing
 

--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/dynamixel/driver.py
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/dynamixel/driver.py
@@ -257,6 +257,7 @@ class DynamixelDriver(DynamixelDriverProtocol):
             self._portHandler.openPort()
             self._portHandler.setBaudRate(self._baudrate)
         except SerialException:
+            self._close_port_quietly()
             detected_ports = self._detect_com_ports()
             if self._port in detected_ports:
                 msg = "Check that you have permissions to access it."
@@ -271,6 +272,7 @@ class DynamixelDriver(DynamixelDriverProtocol):
         try:
             self.read_value_by_name("model_number")
         except (RuntimeError, SerialException):
+            self._close_port_quietly()
             raise ConnectionError(
                 f"Port {self._port} opened but could not read from motors. Make sure no other "
                 "process is using the same port, that all motors are wired correctly and get power."
@@ -396,6 +398,13 @@ class DynamixelDriver(DynamixelDriverProtocol):
     def close(self) -> None:
         self.stop_joint_polling()
         self._portHandler.closePort()
+
+    def _close_port_quietly(self) -> None:
+        """Close the serial port without raising; safe during failed __init__."""
+        try:
+            self._portHandler.closePort()
+        except Exception:
+            pass
 
     def _pulses_to_rad(self, pulses) -> np.ndarray:
         """Convert pulses to radians using motor-specific configuration."""

--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_hardware.py
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_hardware.py
@@ -15,6 +15,7 @@ class GelloHardwareParams(TypedDict):
     gripper: bool
     gripper_range_rad: List[float]
     assembly_offsets: List[float]
+    baudrate: int
     dynamixel_kp_p: List[int]
     dynamixel_kp_i: List[int]
     dynamixel_kp_d: List[int]
@@ -87,6 +88,10 @@ class GelloHardware:
 
     OPERATING_MODE = 5  # CURRENT_BASED_POSITION_MODE
     CURRENT_LIMIT = 600  # mA
+    ALLOWED_BAUDRATES = (57600, 115200, 1000000)
+    BPS_TO_REG = {57600: 1, 115200: 2, 1000000: 3}
+    SCAN_BAUDS = (115200, 57600, 1000000)
+    BAUD_WRITE_SETTLE_S = 0.1
 
     @staticmethod
     def normalize_joint_positions(
@@ -146,6 +151,7 @@ class GelloHardware:
         self._num_total_joints = self._num_arm_joints + (1 if self._gripper else 0)
         self._gripper_range_rad = hardware_config["gripper_range_rad"]
         self._assembly_offsets = np.array(hardware_config["assembly_offsets"])
+        self._desired_baudrate = int(hardware_config["baudrate"])
 
         self._initialize_driver()
 
@@ -180,9 +186,63 @@ class GelloHardware:
         self._driver.start_joint_polling()
 
     def _initialize_driver(self) -> None:
-        """Initialize dynamixel driver with joint IDs and port."""
+        """Open the chain at the live baud, optionally write EEPROM, then reinit at desired."""
+        desired = self._desired_baudrate
+        if desired not in self.ALLOWED_BAUDRATES:
+            raise ValueError(
+                f"Unsupported baudrate {desired}. Allowed: {self.ALLOWED_BAUDRATES}"
+            )
+
         joint_ids = list(range(1, self._num_total_joints + 1))
-        self._driver = DynamixelDriver(joint_ids, port=self._com_port, baudrate=57600)
+        driver = None
+        live = None
+        for candidate in self._baud_scan_order(desired):
+            driver = self._try_open_driver(joint_ids, candidate)
+            if driver is not None:
+                live = candidate
+                break
+
+        if driver is None or live is None:
+            raise ConnectionError(
+                f"No Dynamixels on {self._com_port} at known bauds "
+                f"{self._baud_scan_order(desired)}. Mixed-baud chains are not written; "
+                "recover with Dynamixel Wizard 2.0."
+            )
+
+        if live != desired:
+            self._logger.info(
+                f"GELLO on {self._com_port} answered at {live} baud; "
+                f"writing EEPROM baud_rate for {desired}."
+            )
+            driver.write_value_by_name(
+                "baud_rate", [self.BPS_TO_REG[desired]] * len(joint_ids)
+            )
+            time.sleep(self.BAUD_WRITE_SETTLE_S)
+            driver.close()
+            try:
+                driver = DynamixelDriver(
+                    joint_ids, port=self._com_port, baudrate=desired
+                )
+            except ConnectionError as e:
+                raise ConnectionError(
+                    f"Wrote baud_rate={desired} on {self._com_port} but could not reopen. "
+                    "Chain may be mixed-baud; recover with Dynamixel Wizard 2.0."
+                ) from e
+
+        self._driver = driver
+
+    def _baud_scan_order(self, desired: int) -> list[int]:
+        order: list[int] = []
+        for baud in (desired, *self.SCAN_BAUDS):
+            if baud not in order:
+                order.append(baud)
+        return order
+
+    def _try_open_driver(self, joint_ids: List[int], baudrate: int) -> DynamixelDriver | None:
+        try:
+            return DynamixelDriver(joint_ids, port=self._com_port, baudrate=baudrate)
+        except ConnectionError:
+            return None
 
     def _initialize_parameters(self) -> None:
         """Write all dynamixel configuration parameters to hardware."""

--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_parameter_config.py
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_parameter_config.py
@@ -87,6 +87,31 @@ class GelloParameterConfig:
             ),
             ParameterConfig(
                 ParameterDescriptor(
+                    name="baudrate",
+                    type=ParameterType.PARAMETER_INTEGER,
+                    description="XL330 serial baudrate (57600 factory, 115200, or 1000000)",
+                    additional_constraints="57600, 115200, or 1000000",
+                    read_only=True,
+                ),
+                57600,
+            ),
+            ParameterConfig(
+                ParameterDescriptor(
+                    name="publishing_rate",
+                    type=ParameterType.PARAMETER_INTEGER,
+                    description=(
+                        "ROS joint-state publish timer in Hz (independent of baudrate)"
+                    ),
+                    additional_constraints=(
+                        "any integer ≥ 1; recommended 25@57600, 30 or 50@115200, "
+                        "100@1000000; warn (still start) if above unique-sample ceiling"
+                    ),
+                    read_only=True,
+                ),
+                25,
+            ),
+            ParameterConfig(
+                ParameterDescriptor(
                     name="dynamixel_kp_p",
                     type=ParameterType.PARAMETER_INTEGER_ARRAY,
                     description="Proportional gains",

--- a/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_publisher.py
+++ b/ros2/src/franka_gello_state_publisher/franka_gello_state_publisher/gello_publisher.py
@@ -17,13 +17,14 @@ class GelloPublisher(Node):
 
     def __init__(self) -> None:
         super().__init__("gello_publisher")
-        self.PUBLISHING_RATE = 25  # Hz
 
-        hardware_params: GelloHardwareParams = self._setup_hardware_parameters()
+        hardware_params, publishing_rate = self._setup_hardware_parameters()
+        baudrate = int(hardware_params["baudrate"])
+        self._warn_if_rate_exceeds_baud(publishing_rate, baudrate)
 
         try:
             self.gello_hardware = GelloHardware(hardware_params, self.get_logger())
-        except ConnectionError as e:
+        except (ConnectionError, ValueError) as e:
             self.get_logger().error(f"Failed to initialize GELLO hardware: {e}")
             raise
 
@@ -37,8 +38,10 @@ class GelloPublisher(Node):
             ParameterEvent, "/parameter_events", self.parameter_event_callback, 10
         )
 
-        self.get_logger().info("Publishing GELLO joint states.")
-        self.timer = self.create_timer(1 / self.PUBLISHING_RATE, self.publish_joint_jog)
+        self.get_logger().info(
+            f"Publishing GELLO joint states at {publishing_rate} Hz (baudrate {baudrate})."
+        )
+        self.timer = self.create_timer(1.0 / publishing_rate, self.publish_joint_jog)
 
     def parameter_event_callback(self, event: ParameterEvent) -> None:
         """Handle parameter change events for this node."""
@@ -97,7 +100,19 @@ class GelloPublisher(Node):
         for param in config:
             hardware_params[param.descriptor.name] = self._declare_ros2_param(param)
 
-        return hardware_params
+        publishing_rate = int(hardware_params.pop("publishing_rate"))
+        if publishing_rate < 1:
+            raise ValueError(f"publishing_rate must be >= 1, got {publishing_rate}")
+        return hardware_params, publishing_rate
+
+    def _warn_if_rate_exceeds_baud(self, publishing_rate: int, baudrate: int) -> None:
+        ceilings = {57600: 25, 115200: 50, 1000000: 100}
+        ceiling = ceilings.get(baudrate)
+        if ceiling is not None and publishing_rate > ceiling:
+            self.get_logger().warning(
+                f"publishing_rate {publishing_rate} Hz exceeds unique-sample ceiling "
+                f"~{ceiling} Hz at baudrate {baudrate}; publishes may repeat samples."
+            )
 
 
 def main(args=None):
@@ -105,7 +120,7 @@ def main(args=None):
 
     try:
         gello_publisher = GelloPublisher()
-    except ConnectionError:
+    except (ConnectionError, ValueError):
         rclpy.try_shutdown()
         return
 

--- a/ros2/src/franka_gello_state_publisher/launch/main.launch.py
+++ b/ros2/src/franka_gello_state_publisher/launch/main.launch.py
@@ -38,6 +38,8 @@ def generate_robot_nodes(context):
                     {"gripper": config["gripper"]},
                     {"gripper_range_rad": config["gripper_range_rad"]},
                     {"assembly_offsets": config["assembly_offsets"]},
+                    {"baudrate": config.get("baudrate", 57600)},
+                    {"publishing_rate": config.get("publishing_rate", 25)},
                     {"dynamixel_kp_p": config["dynamixel_kp_p"]},
                     {"dynamixel_kp_i": config["dynamixel_kp_i"]},
                     {"dynamixel_kp_d": config["dynamixel_kp_d"]},

--- a/ros2/src/franka_gello_state_publisher/scripts/get_offsets.py
+++ b/ros2/src/franka_gello_state_publisher/scripts/get_offsets.py
@@ -11,7 +11,6 @@ from franka_gello_state_publisher.gello_hardware import GelloHardware
 
 # The offset in radians from the gripper open position to the closed position.
 GRIPPER_OPEN_TO_CLOSED_RAD = -1.22
-DEFAULT_BAUDRATE = 57600
 
 
 @dataclass
@@ -27,6 +26,9 @@ class Args:
 
     gripper: bool = True
     """Whether or not the gripper is attached."""
+
+    baudrate: int = 57600
+    """Host serial baudrate matching the Dynamixel chain (57600 factory, 115200 after provision)."""
 
     def __post_init__(self):
         assert len(self.joint_signs) == len(self.start_joints)
@@ -77,7 +79,7 @@ def determine_offsets(
 
 def main(args: Args) -> None:
     joint_ids = list(range(1, args.num_total_joints + 1))
-    driver = DynamixelDriver(joint_ids, port=args.port, baudrate=DEFAULT_BAUDRATE)
+    driver = DynamixelDriver(joint_ids, port=args.port, baudrate=args.baudrate)
     joints_raw = driver.get_joints()
     arm_joints_raw = np.array(joints_raw[: args.num_arm_joints])
     assembly_offsets = determine_offsets(


### PR DESCRIPTION
With the following changes now the `baudrate` and `publishing_rate` become per-arm YAML/ROS parameters instead of hardcoded constants (`57600` in `GelloHardware._initialize_driver`, `PUBLISHING_RATE = 25` in `GelloPublisher`). Package configs keep the factory values `57600` / `25`, so stock GELLOs behave exactly as before.

### Init flow

`GelloHardware` no longer assumes the chain speed, it scans, and only writes EEPROM when the live baud disagrees with the config.

```mermaid
flowchart TD
    A[GelloHardware init] --> B[Read desired baudrate]
    B --> C["Try DynamixelDriver at desired, then 115200 / 57600 / 1M"]
    C -->|none open full chain| D[All candidates fail: ConnectionError, no EEPROM write]
    C -->|full chain at live baud| E{live == desired?}
    E -->|yes| F[Keep driver; no EEPROM write]
    E -->|no| G[SyncWrite baud_rate register to all IDs]
    G --> H[close, then DynamixelDriver at desired]
    F --> I[_initialize_parameters, then start_joint_polling]
    H --> I
```

Scan order is `(desired, 115200, 57600, 1000000)`, deduplicated. A chain that never answers in full aborts with `ConnectionError` and writes nothing, mixed-baud chains are left for Dynamixel Wizard 2.0 rather than half-written.

### Baud / rate pairing

| `baudrate` | Unique-Hz ceiling | Valid `publishing_rate` |
|---|---|---|
| `57600` | ~25 | 25 |
| `115200` | ~55 | 30 or 50 |
| `1000000` | ~135 | 100 |

Exceeding the ceiling warns but still starts, the timer just republishes duplicate samples. `latency_timer=1` is recommended for 50 Hz at 115200 and 100 Hz at 1 Mbps (Linux FTDI default is 16 ms); the README troubleshooting section now says so. Also, these values have been calculated to support the best combinations, each user would responsible for selecting a `baud_rate` that supports the required frequency.

### Logging

| When | Level | Message |
|---|---|---|
| After a successful connect | `INFO` | `Publishing GELLO joint states at {publishing_rate} Hz (baudrate {baudrate}).` |
| Live chain baud ≠ YAML `baudrate` | `INFO` | `GELLO on {port} answered at {live} baud; writing EEPROM baud_rate for {desired}.` |
| YAML rate above the unique-Hz ceiling | `WARN` | `publishing_rate N Hz exceeds unique-sample ceiling ~C Hz at baudrate B; publishes may repeat samples.` |
| Scan finds nothing | `ERROR` | `Failed to initialize GELLO hardware: No Dynamixels on {port} at known bauds [...]` |

### CPU cost in our testing

| Setting | Left | Right | Container |
|---|---|---|---|
| 30 Hz / 115200 | 92% | 92% | ~194% |
| 25 Hz / 57600 | 93% | 93% | ~198% |
| 50 Hz / 115200 | 85% | 85% | ~165% |

Raising the rate does not cost more CPU, the polling thread spends less time blocked on the slower serial link, so the faster configurations are actually cheaper.

### Also in this PR

- `DynamixelDriver` closes the port on both `__init__` failure paths (`_close_port_quietly`), so the scan doesn't leak an open handle per failed candidate.
- `get_offsets.py` takes `--baudrate` (default `57600`, no scan); README notes to pass it for provisioned chains.
- `GelloPublisher` and `main()` now also catch `ValueError`, so an unsupported baudrate or `publishing_rate < 1` exits cleanly instead of raising through `rclpy`.

### Compatibility

Both keys are optional, `main.launch.py` defaults them to `57600` / `25`. Existing config files need no edits, and no EEPROM is touched unless a config explicitly asks for a different baud.
